### PR TITLE
feat: add advanced and eliminated player status

### DIFF
--- a/bbpPairings-dotnet-wrapper/Endpoints/Pair.cs
+++ b/bbpPairings-dotnet-wrapper/Endpoints/Pair.cs
@@ -32,6 +32,8 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
                 Results = [],
                 Points = reqPlayer.Points,
                 Name = playerNumbersMap[reqPlayer.Id].ToString(),
+                IsAdvanced = reqPlayer.Status == Request.Player.PlayerStatus.Qualify,
+                IsEliminated = reqPlayer.Status == Request.Player.PlayerStatus.Eliminated,
             };
             for (int i = 1; i <= req.NumberOfRoundsPlayed; i++)
             {
@@ -43,7 +45,7 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
                 };
                 if (m is not null)
                 {
-                    gameResult.OpponentNumber = playerNumbersMap[m.OpponentId];
+                    gameResult.OpponentNumber = playerNumbersMap.GetValueOrDefault(m.OpponentId, 0);
                     // gameResult.Result = m.Won is null ? '=' : m.Won.Value ? '1' : '0';
                     gameResult.Result = m.Result switch
                     {
@@ -113,13 +115,14 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
             public Guid Id { get; set; }
             public float Points { get; set; }
             public ICollection<Match> Matches { get; set; } = [];
+            public PlayerStatus Status { get; set; }
 
             public sealed class Match
             {
                 public int RoundIndex { get; set; }
                 public Guid OpponentId { get; set; }
                 public MatchResult Result { get; set; }
-                public bool IsWhite { get; set; }
+                public bool? IsWhite { get; set; }
             }
             public enum MatchResult
             {
@@ -132,6 +135,12 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
                 FullPointBye,
                 PairingAllocatedBye,
                 ZeroPointBye,
+            }
+            public enum PlayerStatus
+            {
+                Normal,
+                Qualify,
+                Eliminated,
             }
         }
     }

--- a/bbpPairings-dotnet-wrapper/Trf/Player.cs
+++ b/bbpPairings-dotnet-wrapper/Trf/Player.cs
@@ -15,23 +15,16 @@ public class Player
     public int Rank { get; set; }
     public List<float> TieBreaks { get; set; } = [];
     public List<GameResult> Results { get; set; } = [];
+    public bool IsAdvanced { get; set; }
+    public bool IsEliminated { get; set; }
 
     public override string ToString()
     {
-        string TryGet(object? value, int padding, bool isLeftPad)
-        {
-            if (value is null)
-            {
-                return string.Empty.PadLeft(padding);
-            }
-            return isLeftPad ? value.ToString().PadLeft(padding) : value.ToString().PadRight(padding);
-        }
-
         var results = Results.Select(r =>
         {
-            var opponent = TryGet(r.OpponentNumber, 4, true);
+            var opponent = r.OpponentNumber == 0 ? "    " : TryGet(r.OpponentNumber, 4, true);
             var res = r.Result;
-            var color = r.IsWhite is null ? '-' : r.IsWhite.Value ? 'w' : 'b';
+            var color = r.IsWhite is null ? ' ' : r.IsWhite.Value ? 'w' : 'b';
             return $"{opponent} {color} {res}";
         });
         var number = TryGet(Number, 4, true);
@@ -45,7 +38,30 @@ public class Player
         var points = TryGet(Points.ToString("F1"), 4, true);
         var rank = TryGet(Rank, 4, false);
         var resultsStr = string.Join("  ", results);
-        var s = $"001 {number} {sex} {title} {name} {fideRating} {federation} {fideNumber} {birthdate} {points} {rank}  {resultsStr}";
+        var s =
+            $"001 {number} {sex} {title} {name} {fideRating} {federation} {fideNumber} {birthdate} {points} {rank}  {resultsStr}";
         return s;
+    }
+
+    public string ToAnotherString()
+    {
+        if (!IsAdvanced) return string.Empty;
+
+        string number = TryGet(Number, 4, true);
+        string sex = TryGet(string.Empty, 1, true);
+        string title = TryGet(string.Empty, 3, true);
+        string advancedString = IsAdvanced ? "1" : "2";
+
+        return $"XXS {number} {sex} {title} {advancedString}";
+    }
+
+    private string TryGet(object? value, int padding, bool isLeftPad)
+    {
+        if (value is null)
+        {
+            return string.Empty.PadLeft(padding);
+        }
+
+        return isLeftPad ? value.ToString().PadLeft(padding) : value.ToString().PadRight(padding);
     }
 }

--- a/bbpPairings-dotnet-wrapper/Trf/Tournament.cs
+++ b/bbpPairings-dotnet-wrapper/Trf/Tournament.cs
@@ -19,7 +19,12 @@ public class Tournament
         string totalRounds = $"XXR {TotalRounds}";
         string initColor = $"XXC white1";
         var players = Players.Select(p => p.ToString());
-        var s = $"{name}\n{totalRounds}\n{initColor}\n{string.Join("\n", players)}";
+        var advancedPlayers = Players
+            .Where(pl => pl.IsAdvanced || pl.IsEliminated)
+            .Select(p => p.ToAnotherString())
+            .ToList();
+        var str = advancedPlayers.Count > 0 ? $"\n{string.Join("\n", advancedPlayers)}" : string.Empty;
+        var s = $"{name}\n{totalRounds}\n{initColor}\n{string.Join("\n", players)}{str}";;
         return s;
     }
 }


### PR DESCRIPTION
Adds `IsAdvanced` and `IsEliminated` properties to the `Player` class  to track player status. Introduces a new `PlayerStatus` enum to  categorize players. Updates the `ToAnotherString` method to format  advanced players and modifies the tournament string output to include  advanced and eliminated players. Adjusts opponent number retrieval  to use `GetValueOrDefault` for safer access.