### PR TITLE
feat: enhance tournament scoring and improve error handling

### DIFF
--- a/bbpPairings-dotnet-wrapper/Endpoints/Pair.cs
+++ b/bbpPairings-dotnet-wrapper/Endpoints/Pair.cs
@@ -18,6 +18,13 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
         {
             Name = "abc",
             TotalRounds = req.NumberOfRounds,
+            PlayedRounds = req.NumberOfRoundsPlayed,
+            PointsForWin = req.PointsForWin,
+            PointsForDraw = req.PointsForDraw,
+            PointsForLoss = req.PointsForLoss,
+            PointsForZPB = req.PointsForZPB,
+            PointsForForfeitLoss = req.PointsForForfeitLoss,
+            PointsForPAB = req.PointsForPAB,
         };
         List<Player> players = [];
         Dictionary<Guid, int> playerNumbersMap = req.Players
@@ -108,6 +115,12 @@ public sealed class Pair(Pairer pairer) : Endpoint<Pair.Request, Pair.Response>
         public int NumberOfRounds { get; set; }
         public int NumberOfRoundsPlayed { get; set; }
         public PairingSystem PairingSystem { get; set; }
+        public float? PointsForWin { get; set; }
+        public float? PointsForDraw { get; set; }
+        public float? PointsForLoss { get; set; }
+        public float? PointsForZPB { get; set; }
+        public float? PointsForForfeitLoss { get; set; }
+        public float? PointsForPAB { get; set; }
         public ICollection<Player> Players { get; set; } = [];
 
         public class Player

--- a/bbpPairings-dotnet-wrapper/Extensions/StringExtensions.cs
+++ b/bbpPairings-dotnet-wrapper/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+namespace bbpPairings_dotnet_wrapper.Utils;
+
+public static class StringExtensions
+{
+    public static string Pad(this object? value, int padding, bool isLeftPad)
+    {
+        if (value is null)
+        {
+            return string.Empty.PadLeft(padding);
+        }
+
+        return isLeftPad ? value.ToString()!.PadLeft(padding) : value.ToString()!.PadRight(padding);
+    }
+}

--- a/bbpPairings-dotnet-wrapper/Pairer.cs
+++ b/bbpPairings-dotnet-wrapper/Pairer.cs
@@ -89,9 +89,21 @@ public sealed class Pairer(IOptionsSnapshot<ExecutableOptions> optionsSnapshot)
         process.StartInfo = psi;
         process.Start();
 
+        var x = await process.StandardOutput.ReadToEndAsync();
+        var y = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
 
         string output = await outputFile.Reader.ReadToEndAsync();
+        
+        if (string.IsNullOrEmpty(output))
+        {
+            if (!string.IsNullOrEmpty(y) && y.Split(":").Length > 1)
+            {
+                string errorMessage = y.Split(":")[1].Trim();
+                throw new Exception(errorMessage);
+            }
+            throw new Exception();
+        }
 
         return output.Split("\n").ToList();
     }

--- a/bbpPairings-dotnet-wrapper/Program.cs
+++ b/bbpPairings-dotnet-wrapper/Program.cs
@@ -8,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.Configure<ExecutableOptions>(builder.Configuration.GetSection("Executable"));
 builder.Services.AddScoped<Pairer>();
 builder.Services
+    
     .AddFastEndpoints()
     .SwaggerDocument();
 
@@ -16,7 +17,9 @@ var app = builder.Build();
 app.UseHttpsRedirection();
 app.UseRouting();
 
-app.UseFastEndpoints()
+app
+    .UseDefaultExceptionHandler()
+    .UseFastEndpoints()
     .UseSwaggerGen();
 
 app.Run();

--- a/bbpPairings-dotnet-wrapper/Trf/Player.cs
+++ b/bbpPairings-dotnet-wrapper/Trf/Player.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using bbpPairings_dotnet_wrapper.Utils;
 
 namespace bbpPairings_dotnet_wrapper.Trf;
 
@@ -20,26 +21,53 @@ public class Player
 
     public override string ToString()
     {
+        // var resultsFormatted = Results.Select(r =>
+        // {
+        //     var opponent = r.OpponentNumber == 0 ? "    " : r.OpponentNumber.Pad(4, true);
+        //     var color = r.IsWhite is null ? ' ' : (r.IsWhite.Value ? 'w' : 'b');
+        //     var res = r.Result;
+        //     return $"{opponent} {color} {res}";
+        // });
+        //
+        // var parts = new List<string>
+        // {
+        //     "001",
+        //     Number.Pad(4, true),
+        //     string.Empty.Pad(1, true),          // Sex
+        //     Title.Pad(3, true),
+        //     Name.Pad(29, false),
+        //     Rating.Pad(4, true),
+        //     Federation.Pad(4, true),
+        //     string.Empty.Pad(4, true),          // FIDE Number
+        //     string.Empty.Pad(19, true),         // Birthdate
+        //     Points.ToString("F1").Pad(4, true),
+        //     Rank.Pad(4, false)
+        // };
+        //
+        // // Add results, joined with two spaces
+        // var resultsStr = string.Join("  ", resultsFormatted);
+        // parts.Add(resultsStr);
+        //
+        // return string.Join(" ", parts);
         var results = Results.Select(r =>
         {
-            var opponent = r.OpponentNumber == 0 ? "    " : TryGet(r.OpponentNumber, 4, true);
+            var opponent = r.OpponentNumber == 0 ? "    " : r.OpponentNumber.Pad( 4, true);
             var res = r.Result;
             var color = r.IsWhite is null ? ' ' : r.IsWhite.Value ? 'w' : 'b';
             return $"{opponent} {color} {res}";
         });
-        var number = TryGet(Number, 4, true);
-        var sex = TryGet(string.Empty, 1, true);
-        var title = TryGet(Title, 3, true);
-        var name = TryGet(Name, 29, false);
-        var fideRating = TryGet(Rating, 4, true);
-        var federation = TryGet(Federation, 4, true);
-        var fideNumber = TryGet(string.Empty, 4, true);
-        var birthdate = TryGet(string.Empty, 19, true);
-        var points = TryGet(Points.ToString("F1"), 4, true);
-        var rank = TryGet(Rank, 4, false);
+        var number = Number.Pad(4, true);
+        var sex = string.Empty.Pad(1, true);
+        var title = Title.Pad(3, true);
+        var name = Name.Pad( 29, false);
+        var fideRating = Rating.Pad( 4, true);
+        var federation = Federation.Pad( 4, true);
+        var fideNumber = string.Empty.Pad( 4, true);
+        var birthdate = string.Empty.Pad( 19, true);
+        var points = Points.ToString("F1").Pad( 4, true);
+        var rank = Rank.Pad( 4, false);
         var resultsStr = string.Join("  ", results);
-        var s =
-            $"001 {number} {sex} {title} {name} {fideRating} {federation} {fideNumber} {birthdate} {points} {rank}  {resultsStr}";
+        var s = $"001 {number} {sex} {title} {name} {fideRating} {federation} {fideNumber} {birthdate} {points} {rank}  {resultsStr}";
         return s;
     }
 

--- a/bbpPairings-dotnet-wrapper/Trf/Tournament.cs
+++ b/bbpPairings-dotnet-wrapper/Trf/Tournament.cs
@@ -1,3 +1,5 @@
+using bbpPairings_dotnet_wrapper.Utils;
+
 namespace bbpPairings_dotnet_wrapper.Trf;
 
 public class Tournament
@@ -12,19 +14,51 @@ public class Tournament
     public char InitialColor { get; set; } // 'w' hoặc 'b'
     public string Arbiter { get; set; }
     public string ContactInfo { get; set; }
+    public float? PointsForWin { get; set; }
+    public float? PointsForDraw { get; set; }
+
+    public float? PointsForLoss { get; set; }
+
+    // zero point bye
+    public float? PointsForZPB { get; set; }
+
+    public float? PointsForForfeitLoss { get; set; }
+
+    // pairing allocated bye
+    public float? PointsForPAB { get; set; }
     public List<Player> Players { get; set; } = [];
+
     public override string ToString()
     {
-        string name = $"012 {Name}";
-        string totalRounds = $"XXR {TotalRounds}";
-        string initColor = $"XXC white1";
-        var players = Players.Select(p => p.ToString());
-        var advancedPlayers = Players
+        var lines = new List<string>
+        {
+            $"012 {Name}",
+            $"XXR {TotalRounds}",
+            $"XXC white1"
+        };
+
+        if (PointsForWin is not null) lines.Add($"BBW {PointsForWin.Pad(4, isLeftPad: true)}");
+        if (PointsForDraw is not null) lines.Add($"BBD {PointsForDraw.Pad(4, isLeftPad: true)}");
+        if (PointsForLoss is not null) lines.Add($"BBL {PointsForLoss.Pad(4, isLeftPad: true)}");
+        if (PointsForZPB is not null) lines.Add($"BBZ {PointsForZPB.Pad(4, isLeftPad: true)}");
+        if (PointsForForfeitLoss is not null) lines.Add($"BBF {PointsForForfeitLoss.Pad(4, isLeftPad: true)}");
+        if (PointsForPAB is not null) lines.Add($"BBU {PointsForPAB.Pad(4, isLeftPad: true)}");
+
+        // Add players
+        lines.AddRange(Players.Select(p => p.ToString()));
+
+        // Add advanced/eliminated players if any
+        var advanced = Players
             .Where(pl => pl.IsAdvanced || pl.IsEliminated)
             .Select(p => p.ToAnotherString())
             .ToList();
-        var str = advancedPlayers.Count > 0 ? $"\n{string.Join("\n", advancedPlayers)}" : string.Empty;
-        var s = $"{name}\n{totalRounds}\n{initColor}\n{string.Join("\n", players)}{str}";;
-        return s;
+
+        if (advanced.Count > 0)
+        {
+            lines.Add(""); // Blank line before advanced players
+            lines.AddRange(advanced);
+        }
+
+        return string.Join("\n", lines);
     }
 }


### PR DESCRIPTION
Add nullable float properties for various point types (win, draw, loss, zero point bye, forfeit loss, pairing allocated bye) to Tournament and Pair request models to support flexible scoring configurations.

Refactor Tournament.ToString() to include new point fields with proper padding and format output with players and advanced players sections.

Introduce StringExtensions.Pad() to simplify string padding logic.

Improve Pairer process output handling by reading both stdout and stderr, throwing detailed exceptions when output is empty and error info is present.

Update appsettings.Development.json to use Windows executable filename.

Add default exception handler middleware in Program.cs for better error management.